### PR TITLE
Ignore exceptions when closing connection in error state.

### DIFF
--- a/lib/src/memcache_native_connection.dart
+++ b/lib/src/memcache_native_connection.dart
@@ -757,7 +757,7 @@ class MemCacheNativeConnection {
   }
 
   void onError(error) {
-    close(error).catchError((_) {});
+    close(error);
   }
 
   void onDone() {
@@ -785,6 +785,10 @@ class MemCacheNativeConnection {
       pending.completeError(new MemCacheError(error));
     });
 
-    await _socket.close();
+    try {
+      await _socket.close();
+    } catch (_) {
+      // Ignore errors. We've failed the pending requests anyway.
+    }
   }
 }

--- a/lib/src/memcache_native_connection.dart
+++ b/lib/src/memcache_native_connection.dart
@@ -757,7 +757,7 @@ class MemCacheNativeConnection {
   }
 
   void onError(error) {
-    close(error);
+    close(error).catchError((_) {});
   }
 
   void onDone() {


### PR DESCRIPTION
If the socket closes with error, there's a good chance that close() will
throw an exception, which was currently unhandled. This led to a crash
in Pub.

Fixed by catching and ignoring errors in onError().